### PR TITLE
Removal of OBIS and Data_One from default seeds.

### DIFF
--- a/src/main/java/bio/guoda/preston/cmd/CmdUpdate.java
+++ b/src/main/java/bio/guoda/preston/cmd/CmdUpdate.java
@@ -30,8 +30,6 @@ public class CmdUpdate extends CmdActivity {
         add(Seeds.IDIGBIO.getIRIString());
         add(Seeds.GBIF.getIRIString());
         add(Seeds.BIOCASE.getIRIString());
-        add(Seeds.OBIS.getIRIString());
-        //add(Seeds.DATA_ONE.getIRIString());
     }};
 
     @Parameter(description = "[url1] [url2] ...",


### PR DESCRIPTION
OBIS and Data_One have been removed, as discussed with @mielliott .