### PR TITLE
Activity tracking

### DIFF
--- a/src/main/java/bio/guoda/preston/RefNodeConstants.java
+++ b/src/main/java/bio/guoda/preston/RefNodeConstants.java
@@ -31,6 +31,9 @@ public class RefNodeConstants {
     public static final UUID BIODIVERSITY_DATASET_GRAPH_UUID = UUID.fromString("0659a54f-b713-4f86-a917-5be166a14110");
     public static final IRI BIODIVERSITY_DATASET_GRAPH = toIRI(BIODIVERSITY_DATASET_GRAPH_UUID.toString());
 
+    public static final IRI STARTED_AT_TIME = RefNodeFactory.toIRI(URI.create("http://www.w3.org/ns/prov#startedAtTime"));
+    public static final IRI ENDED_AT_TIME = RefNodeFactory.toIRI(URI.create("http://www.w3.org/ns/prov#endedAtTime"));
+
     public static final IRI USED_BY = toIRI("http://www.w3.org/ns/prov#usedBy");
     public static final IRI AGENT = toIRI("http://www.w3.org/ns/prov#Agent");
     public static final IRI SOFTWARE_AGENT = toIRI("http://www.w3.org/ns/prov#SoftwareAgent");

--- a/src/main/java/bio/guoda/preston/process/ActivityUtil.java
+++ b/src/main/java/bio/guoda/preston/process/ActivityUtil.java
@@ -47,6 +47,7 @@ public class ActivityUtil {
     public static BlankNodeOrIRI emitAsNewActivity(Stream<Quad> quadStream, StatementEmitter emitter, Optional<BlankNodeOrIRI> parentActivity) {
         BlankNodeOrIRI newActivity = toIRI(UUID.randomUUID());
         emitAsNamedActivity(quadStream, emitter, parentActivity, newActivity);
+        endInformedActivity(emitter, newActivity);
         return newActivity;
     }
 

--- a/src/main/java/bio/guoda/preston/process/ActivityUtil.java
+++ b/src/main/java/bio/guoda/preston/process/ActivityUtil.java
@@ -34,7 +34,6 @@ public class ActivityUtil {
     public static BlankNodeOrIRI emitAsNewActivity(Stream<Quad> quadStream, StatementEmitter emitter, Optional<BlankNodeOrIRI> parentActivity) {
         BlankNodeOrIRI newActivity = toIRI(UUID.randomUUID());
         emitAsNamedActivity(quadStream, emitter, parentActivity, newActivity);
-        endInformedActivity(emitter, newActivity);
         return newActivity;
     }
 

--- a/src/main/java/bio/guoda/preston/process/ActivityUtil.java
+++ b/src/main/java/bio/guoda/preston/process/ActivityUtil.java
@@ -21,8 +21,7 @@ public class ActivityUtil {
     private static final boolean emitStartedAt = false;
     private static final boolean emitEndedAt = false;
 
-    private static BlankNodeOrIRI beginInformedActivity(StatementEmitter emitter, Optional<BlankNodeOrIRI> sourceActivity) {
-        BlankNodeOrIRI newActivity = toIRI(UUID.randomUUID());
+    private static void beginInformedActivity(StatementEmitter emitter, BlankNodeOrIRI newActivity, Optional<BlankNodeOrIRI> sourceActivity) {
         emitter.emit(toStatement(newActivity, newActivity, IS_A, ACTIVITY));
 
         if (sourceActivity.isPresent()) {
@@ -32,8 +31,6 @@ public class ActivityUtil {
         if (emitStartedAt) {
             emitter.emit(toStatement(newActivity, newActivity, STARTED_AT_TIME, RefNodeFactory.nowDateTimeLiteral()));
         }
-
-        return newActivity;
     }
 
     private static void endInformedActivity(StatementEmitter emitter, BlankNodeOrIRI activity) {
@@ -48,9 +45,14 @@ public class ActivityUtil {
     }
 
     public static BlankNodeOrIRI emitAsNewActivity(Stream<Quad> quadStream, StatementEmitter emitter, Optional<BlankNodeOrIRI> parentActivity) {
-        BlankNodeOrIRI activity = beginInformedActivity(emitter, parentActivity);
-        emitWithActivityName(quadStream, emitter, activity);
-        endInformedActivity(emitter, activity);
-        return activity;
+        BlankNodeOrIRI newActivity = toIRI(UUID.randomUUID());
+        emitAsNamedActivity(quadStream, emitter, parentActivity, newActivity);
+        return newActivity;
+    }
+
+    public static void emitAsNamedActivity(Stream<Quad> quadStream, StatementEmitter emitter, Optional<BlankNodeOrIRI> parentActivity, BlankNodeOrIRI activityName) {
+        beginInformedActivity(emitter, activityName, parentActivity);
+        emitWithActivityName(quadStream, emitter, activityName);
+        endInformedActivity(emitter, activityName);
     }
 }

--- a/src/main/java/bio/guoda/preston/process/ActivityUtil.java
+++ b/src/main/java/bio/guoda/preston/process/ActivityUtil.java
@@ -1,6 +1,5 @@
 package bio.guoda.preston.process;
 
-import bio.guoda.preston.model.RefNodeFactory;
 import org.apache.commons.rdf.api.BlankNodeOrIRI;
 import org.apache.commons.rdf.api.Quad;
 
@@ -9,17 +8,12 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 import static bio.guoda.preston.RefNodeConstants.ACTIVITY;
-import static bio.guoda.preston.RefNodeConstants.ENDED_AT_TIME;
 import static bio.guoda.preston.RefNodeConstants.IS_A;
-import static bio.guoda.preston.RefNodeConstants.STARTED_AT_TIME;
 import static bio.guoda.preston.RefNodeConstants.WAS_INFORMED_BY;
 import static bio.guoda.preston.model.RefNodeFactory.toIRI;
 import static bio.guoda.preston.model.RefNodeFactory.toStatement;
 
 public class ActivityUtil {
-
-    private static final boolean emitStartedAt = false;
-    private static final boolean emitEndedAt = false;
 
     private static void beginInformedActivity(StatementEmitter emitter, BlankNodeOrIRI newActivity, Optional<BlankNodeOrIRI> sourceActivity) {
         emitter.emit(toStatement(newActivity, newActivity, IS_A, ACTIVITY));
@@ -27,16 +21,9 @@ public class ActivityUtil {
         if (sourceActivity.isPresent()) {
             emitter.emit(toStatement(newActivity, newActivity, WAS_INFORMED_BY, sourceActivity.get()));
         }
-
-        if (emitStartedAt) {
-            emitter.emit(toStatement(newActivity, newActivity, STARTED_AT_TIME, RefNodeFactory.nowDateTimeLiteral()));
-        }
     }
 
     private static void endInformedActivity(StatementEmitter emitter, BlankNodeOrIRI activity) {
-        if (emitEndedAt) {
-            emitter.emit(toStatement(activity, activity, ENDED_AT_TIME, RefNodeFactory.nowDateTimeLiteral()));
-        }
     }
 
     private static void emitWithActivityName(Stream<Quad> quadStream, StatementEmitter emitter, BlankNodeOrIRI activity) {

--- a/src/main/java/bio/guoda/preston/process/ActivityUtil.java
+++ b/src/main/java/bio/guoda/preston/process/ActivityUtil.java
@@ -33,11 +33,11 @@ public class ActivityUtil {
 
     public static BlankNodeOrIRI emitAsNewActivity(Stream<Quad> quadStream, StatementEmitter emitter, Optional<BlankNodeOrIRI> parentActivity) {
         BlankNodeOrIRI newActivity = toIRI(UUID.randomUUID());
-        emitAsNamedActivity(quadStream, emitter, parentActivity, newActivity);
+        emitAsNewNamedActivity(quadStream, emitter, parentActivity, newActivity);
         return newActivity;
     }
 
-    public static void emitAsNamedActivity(Stream<Quad> quadStream, StatementEmitter emitter, Optional<BlankNodeOrIRI> parentActivity, BlankNodeOrIRI activityName) {
+    public static void emitAsNewNamedActivity(Stream<Quad> quadStream, StatementEmitter emitter, Optional<BlankNodeOrIRI> parentActivity, BlankNodeOrIRI activityName) {
         beginInformedActivity(emitter, activityName, parentActivity);
         emitWithActivityName(quadStream, emitter, activityName);
         endInformedActivity(emitter, activityName);

--- a/src/main/java/bio/guoda/preston/process/ActivityUtil.java
+++ b/src/main/java/bio/guoda/preston/process/ActivityUtil.java
@@ -1,11 +1,14 @@
 package bio.guoda.preston.process;
 
 import org.apache.commons.rdf.api.BlankNodeOrIRI;
+import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Quad;
+import org.apache.jena.shared.uuid.JenaUUID;
 
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static bio.guoda.preston.model.RefNodeFactory.toIRI;
@@ -13,10 +16,9 @@ import static bio.guoda.preston.model.RefNodeFactory.toStatement;
 
 public class ActivityUtil {
 
-    public static BlankNodeOrIRI beginInformedActivity(StatementEmitter emitter, Optional<BlankNodeOrIRI> parentActivity) {
-        List<Quad> statements = new LinkedList<Quad>();
+    private static BlankNodeOrIRI beginInformedActivity(StatementEmitter emitter, Optional<BlankNodeOrIRI> parentActivity) {
+        List<Quad> statements = new LinkedList<>();
         BlankNodeOrIRI newActivity = parentActivity.orElse(null);
-//        IRI newActivity = toIRI(UUID.randomUUID());
 
 //        statements.add(toStatement(newActivity, newActivity, IS_A, ACTIVITY));
 
@@ -32,11 +34,11 @@ public class ActivityUtil {
         return newActivity;
     }
 
-    public static void endInformedActivity(StatementEmitter emitter, BlankNodeOrIRI activity) {
+    private static void endInformedActivity(StatementEmitter emitter, BlankNodeOrIRI activity) {
 //        emitter.emit(toStatement(activity, activity, toIRI("http://www.w3.org/ns/prov#endedAtTime"), RefNodeFactory.nowDateTimeLiteral()));
     }
 
-    public static void emitWithActivityName(Stream<Quad> quadStream, StatementEmitter emitter, BlankNodeOrIRI activity) {
+    private static void emitWithActivityName(Stream<Quad> quadStream, StatementEmitter emitter, BlankNodeOrIRI activity) {
         quadStream.map(quad -> toStatement(activity, quad.getSubject(), quad.getPredicate(), quad.getObject()))
                 .forEach(emitter::emit);
     }

--- a/src/main/java/bio/guoda/preston/process/ActivityUtil.java
+++ b/src/main/java/bio/guoda/preston/process/ActivityUtil.java
@@ -1,41 +1,45 @@
 package bio.guoda.preston.process;
 
+import bio.guoda.preston.model.RefNodeFactory;
 import org.apache.commons.rdf.api.BlankNodeOrIRI;
-import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Quad;
-import org.apache.jena.shared.uuid.JenaUUID;
 
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 
+import static bio.guoda.preston.RefNodeConstants.ACTIVITY;
+import static bio.guoda.preston.RefNodeConstants.ENDED_AT_TIME;
+import static bio.guoda.preston.RefNodeConstants.IS_A;
+import static bio.guoda.preston.RefNodeConstants.STARTED_AT_TIME;
+import static bio.guoda.preston.RefNodeConstants.WAS_INFORMED_BY;
 import static bio.guoda.preston.model.RefNodeFactory.toIRI;
 import static bio.guoda.preston.model.RefNodeFactory.toStatement;
 
 public class ActivityUtil {
 
-    private static BlankNodeOrIRI beginInformedActivity(StatementEmitter emitter, Optional<BlankNodeOrIRI> parentActivity) {
-        List<Quad> statements = new LinkedList<>();
-        BlankNodeOrIRI newActivity = parentActivity.orElse(null);
+    private static final boolean emitStartedAt = false;
+    private static final boolean emitEndedAt = false;
 
-//        statements.add(toStatement(newActivity, newActivity, IS_A, ACTIVITY));
+    private static BlankNodeOrIRI beginInformedActivity(StatementEmitter emitter, Optional<BlankNodeOrIRI> sourceActivity) {
+        BlankNodeOrIRI newActivity = toIRI(UUID.randomUUID());
+        emitter.emit(toStatement(newActivity, newActivity, IS_A, ACTIVITY));
 
-//        if (sourceActivity.isPresent()) {
-//            statements.add(
-//                    toStatement(newActivity, newActivity, WAS_INFORMED_BY, sourceActivity.get())
-//            );
-//        }
+        if (sourceActivity.isPresent()) {
+            emitter.emit(toStatement(newActivity, newActivity, WAS_INFORMED_BY, sourceActivity.get()));
+        }
 
-//        statements.add(toStatement(newActivity, newActivity, STARTED_AT, time));
-        statements.forEach(emitter::emit);
+        if (emitStartedAt) {
+            emitter.emit(toStatement(newActivity, newActivity, STARTED_AT_TIME, RefNodeFactory.nowDateTimeLiteral()));
+        }
 
         return newActivity;
     }
 
     private static void endInformedActivity(StatementEmitter emitter, BlankNodeOrIRI activity) {
-//        emitter.emit(toStatement(activity, activity, toIRI("http://www.w3.org/ns/prov#endedAtTime"), RefNodeFactory.nowDateTimeLiteral()));
+        if (emitEndedAt) {
+            emitter.emit(toStatement(activity, activity, ENDED_AT_TIME, RefNodeFactory.nowDateTimeLiteral()));
+        }
     }
 
     private static void emitWithActivityName(Stream<Quad> quadStream, StatementEmitter emitter, BlankNodeOrIRI activity) {

--- a/src/test/java/bio/guoda/preston/cmd/CmdUpdateTest.java
+++ b/src/test/java/bio/guoda/preston/cmd/CmdUpdateTest.java
@@ -61,16 +61,16 @@ public class CmdUpdateTest {
 
         assertThat(graphNamesIgnoreDefault.size(), is(quads.size()));
 
-        long unique = graphNamesIgnoreDefault.stream()
+        long numActivities = graphNamesIgnoreDefault.stream()
                 .map(UUID::fromString)
                 .distinct()
                 .count();
-        assertThat(unique, greaterThan(1L));
+        assertThat(numActivities, greaterThan(1L));
 
-        long informed = quads.stream()
+        long numInformedActivities = quads.stream()
                 .filter(x -> x.getPredicate().equals(WAS_INFORMED_BY))
                 .count();
-        assertThat(informed, is(unique - 1)); // Only the first activity should lack WAS_INFORMED_BY
+        assertThat(numInformedActivities, is(numActivities - 1));
     }
 
 

--- a/src/test/java/bio/guoda/preston/cmd/CmdUpdateTest.java
+++ b/src/test/java/bio/guoda/preston/cmd/CmdUpdateTest.java
@@ -7,8 +7,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.rdf.api.IRI;
-import org.apache.commons.rdf.api.RDFTerm;
 import org.apache.commons.rdf.api.Quad;
+import org.apache.commons.rdf.api.RDFTerm;
 import org.hamcrest.core.Is;
 import org.junit.Test;
 
@@ -16,18 +16,17 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import static bio.guoda.preston.RefNodeConstants.WAS_INFORMED_BY;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertThat;
 
 public class CmdUpdateTest {
@@ -66,7 +65,12 @@ public class CmdUpdateTest {
                 .map(UUID::fromString)
                 .distinct()
                 .count();
-        assertThat(unique, is(1L));
+        assertThat(unique, greaterThan(1L));
+
+        long informed = quads.stream()
+                .filter(x -> x.getPredicate().equals(WAS_INFORMED_BY))
+                .count();
+        assertThat(informed, is(unique - 1)); // Only the first activity should lack WAS_INFORMED_BY
     }
 
 

--- a/src/test/java/bio/guoda/preston/process/ActivityUtilTest.java
+++ b/src/test/java/bio/guoda/preston/process/ActivityUtilTest.java
@@ -7,63 +7,54 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static bio.guoda.preston.RefNodeConstants.ACTIVITY;
 import static bio.guoda.preston.RefNodeConstants.IS_A;
+import static bio.guoda.preston.RefNodeConstants.WAS_INFORMED_BY;
 import static bio.guoda.preston.model.RefNodeFactory.toIRI;
 import static bio.guoda.preston.model.RefNodeFactory.toStatement;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class ActivityUtilTest {
 
     @Test
-    public void startActivity() {
-        List<Quad> listQuads = new ArrayList<>();
-        Optional<BlankNodeOrIRI> sourceActivity = Optional.of(toIRI("activityIRI"));
-
-        BlankNodeOrIRI newActivity = ActivityUtil.beginInformedActivity(listQuads::add, sourceActivity);
-
-        assertThat(newActivity, is(toIRI("activityIRI")));
-//        assertThat(listQuads.size(), greaterThan(0));
-//        assertThat(listQuads.get(0), is(toStatement(toIRI("activityIRI"), IS_A, ACTIVITY)));
-    }
-
-    @Test
-    public void endActivity() {
-        List<Quad> listQuads = new ArrayList<>();
-        BlankNodeOrIRI activity = toIRI("someActivity");
-
-        ActivityUtil.endInformedActivity(listQuads::add, activity);
-
-        assertThat(listQuads.size(), is(0));
-    }
-
-    @Test
-    public void emitActivityStatement() {
-        List<Quad> listQuads = new ArrayList<>();
-        BlankNodeOrIRI activity = toIRI("activityIRI");
-        Quad unlabeledStatement = toStatement(toIRI("cats"), toIRI("are"), toIRI("small"));
-
-        ActivityUtil.emitWithActivityName(Stream.of(unlabeledStatement), listQuads::add, activity);
-
-        assertThat(listQuads.size(), is(1));
-        assertThat(listQuads.get(0), is(toStatement(activity, unlabeledStatement.getSubject(), unlabeledStatement.getPredicate(), unlabeledStatement.getObject())));
-    }
-
-    @Test
-    public void emitActivity() {
-        List<Quad> listQuads = new ArrayList<>();
-        BlankNodeOrIRI parentActivity = toIRI("someActivity");
+    public void emitUninformedActivity() {
+        List<Quad> nodes = new ArrayList<>();
         Quad first = toStatement(toIRI("cats"), toIRI("are"), toIRI("small"));
         Stream<Quad> unlabeledStatements = Stream.of(first);
 
-        BlankNodeOrIRI newActivity = ActivityUtil.emitAsNewActivity(unlabeledStatements, listQuads::add, Optional.of(parentActivity));
+        final BlankNodeOrIRI newActivity = ActivityUtil.emitAsNewActivity(unlabeledStatements, nodes::add, Optional.empty());
 
-        assertThat(listQuads.size(), greaterThan(0));
-        assertTrue(listQuads.contains(toStatement(newActivity, first.getSubject(), first.getPredicate(), first.getObject())));
+        assertTrue(isUUID(newActivity));
+
+        assertThat(nodes.size(), is(2));
+        assertTrue(nodes.contains(toStatement(newActivity, newActivity, IS_A, ACTIVITY)));
+        assertTrue(nodes.contains(toStatement(newActivity, first.getSubject(), first.getPredicate(), first.getObject())));
+    }
+
+    @Test
+    public void emitInformedActivity() {
+        List<Quad> nodes = new ArrayList<>();
+        final BlankNodeOrIRI sourceActivity = toIRI("someActivity");
+        Quad first = toStatement(toIRI("cats"), toIRI("are"), toIRI("small"));
+        Stream<Quad> unlabeledStatements = Stream.of(first);
+
+        final BlankNodeOrIRI newActivity = ActivityUtil.emitAsNewActivity(unlabeledStatements, nodes::add, Optional.of(sourceActivity));
+
+        assertTrue(isUUID(newActivity));
+
+        assertThat(nodes.size(), is(3));
+        assertTrue(nodes.contains(toStatement(newActivity, newActivity, IS_A, ACTIVITY)));
+        assertTrue(nodes.contains(toStatement(newActivity, newActivity, WAS_INFORMED_BY, sourceActivity)));
+        assertTrue(nodes.contains(toStatement(newActivity, first.getSubject(), first.getPredicate(), first.getObject())));
+    }
+
+    private boolean isUUID(BlankNodeOrIRI uuid) {
+        String uuidString = uuid.toString();
+        return uuidString.matches("^<[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}>$");
     }
 }

--- a/src/test/java/bio/guoda/preston/process/ContentResolverTest.java
+++ b/src/test/java/bio/guoda/preston/process/ContentResolverTest.java
@@ -12,6 +12,7 @@ import bio.guoda.preston.store.KeyValueStoreLocalFileSystem;
 import bio.guoda.preston.store.TestUtil;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.rdf.api.BlankNodeOrIRI;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Triple;
 import org.apache.commons.rdf.api.Quad;
@@ -30,6 +31,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 
+import static bio.guoda.preston.model.RefNodeFactory.toIRI;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -68,8 +70,8 @@ public class ContentResolverTest {
 
 
         URI testURI = getClass().getResource("test.txt").toURI();
-        IRI providedNode = RefNodeFactory.toIRI(testURI);
-        Quad relation = RefNodeFactory.toStatement(providedNode, RefNodeConstants.HAS_VERSION, RefNodeFactory.toBlank());
+        IRI providedNode = toIRI(testURI);
+        Quad relation = RefNodeFactory.toStatement(TestUtil.getTestCrawlContext().getActivity(), providedNode, RefNodeConstants.HAS_VERSION, RefNodeFactory.toBlank());
 
         listener.on(relation);
 
@@ -77,8 +79,10 @@ public class ContentResolverTest {
         assertFalse(refNodes.isEmpty());
         assertThat(refNodes.size(), is(7));
 
+        BlankNodeOrIRI activity = refNodes.get(0).getGraphName().get();
+
         assertThat(refNodes.get(0).getPredicate(), is(RefNodeConstants.WAS_GENERATED_BY));
-        assertThat(refNodes.get(0).getObject(), is(TestUtil.getTestCrawlContext().getActivity()));
+        assertThat(refNodes.get(0).getObject(), is(activity));
         
         String expectedHash = "50d7a905e3046b88638362cc34a31a1ae534766ca55e3aa397951efe653b062b";
         String expectedValue = "https://example.org";

--- a/src/test/java/bio/guoda/preston/process/RegistryReaderALATest.java
+++ b/src/test/java/bio/guoda/preston/process/RegistryReaderALATest.java
@@ -1,6 +1,7 @@
 package bio.guoda.preston.process;
 
 import bio.guoda.preston.Seeds;
+import bio.guoda.preston.model.RefNodeFactory;
 import bio.guoda.preston.store.TestUtil;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDFTerm;
@@ -15,8 +16,12 @@ import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 
+import static bio.guoda.preston.MimeTypes.MIME_TYPE_JSON;
+import static bio.guoda.preston.RefNodeConstants.ACTIVITY;
 import static bio.guoda.preston.RefNodeConstants.HAS_VERSION;
+import static bio.guoda.preston.RefNodeConstants.IS_A;
 import static bio.guoda.preston.RefNodeConstants.WAS_ASSOCIATED_WITH;
+import static bio.guoda.preston.TripleMatcher.hasTriple;
 import static bio.guoda.preston.model.RefNodeFactory.getVersionSource;
 import static bio.guoda.preston.model.RefNodeFactory.toIRI;
 import static bio.guoda.preston.model.RefNodeFactory.toLiteral;
@@ -32,8 +37,8 @@ public class RegistryReaderALATest {
         ArrayList<Quad> nodes = new ArrayList<>();
         RegistryReaderALA registryReader = new RegistryReaderALA(TestUtil.getTestBlobStore(), nodes::add);
         registryReader.on(toStatement(Seeds.ALA, WAS_ASSOCIATED_WITH, toIRI("http://example.org/someActivity")));
-        Assert.assertThat(nodes.size(), is(6));
-        assertThat(getVersionSource(nodes.get(5)).getIRIString(), is("https://collections.ala.org.au/ws/dataResource?status=dataAvailable"));
+        Assert.assertThat(nodes.size(), is(7));
+        assertThat(getVersionSource(nodes.get(6)).getIRIString(), is("https://collections.ala.org.au/ws/dataResource?status=dataAvailable"));
     }
 
     @Test
@@ -44,7 +49,7 @@ public class RegistryReaderALATest {
         registryReader.on(toStatement(toIRI("https://collections.ala.org.au/ws/dataResource?status=dataAvailable&resourceType=records"),
                 HAS_VERSION,
                 toIRI("https://some")));
-        assertThat(nodes.size(), is(0));
+        assertThat(nodes.size(), is(1));
     }
 
     @Test
@@ -72,11 +77,11 @@ public class RegistryReaderALATest {
 
         registryReader.on(firstPage);
 
-        Assert.assertThat(nodes.size(), is(3981));
+        Assert.assertThat(nodes.size(), is(3982));
         Quad secondPage = nodes.get(nodes.size() - 3);
-        assertThat(secondPage.toString(), is("<https://collections.ala.org.au/ws/dataResource/dr8052> <http://purl.org/pav/createdBy> <https://ala.org.au> ."));
+        assertThat(secondPage, hasTriple(toStatement(toIRI("https://collections.ala.org.au/ws/dataResource/dr8052"), toIRI("http://purl.org/pav/createdBy"), toIRI("https://ala.org.au"))));
         secondPage = nodes.get(nodes.size() - 2);
-        assertThat(secondPage.toString(), is("<https://collections.ala.org.au/ws/dataResource/dr8052> <http://purl.org/dc/elements/1.1/format> \"application/json\" ."));
+        assertThat(secondPage, hasTriple(toStatement(toIRI("https://collections.ala.org.au/ws/dataResource/dr8052"), toIRI("http://purl.org/dc/elements/1.1/format"), RefNodeFactory.toLiteral(MIME_TYPE_JSON))));
         Quad thirdPage = nodes.get(nodes.size() - 1);
         assertThat(getVersionSource(thirdPage).toString(), is("<https://collections.ala.org.au/ws/dataResource/dr8052>"));
     }

--- a/src/test/java/bio/guoda/preston/process/RegistryReaderBHLTest.java
+++ b/src/test/java/bio/guoda/preston/process/RegistryReaderBHLTest.java
@@ -3,9 +3,8 @@ package bio.guoda.preston.process;
 import bio.guoda.preston.Seeds;
 import bio.guoda.preston.store.TestUtil;
 import org.apache.commons.rdf.api.IRI;
-import org.apache.commons.rdf.api.RDFTerm;
-import org.apache.commons.rdf.api.Triple;
 import org.apache.commons.rdf.api.Quad;
+import org.apache.commons.rdf.api.RDFTerm;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -13,7 +12,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.List;
 
 import static bio.guoda.preston.RefNodeConstants.HAS_VERSION;
 import static bio.guoda.preston.RefNodeConstants.WAS_ASSOCIATED_WITH;
@@ -23,8 +21,6 @@ import static bio.guoda.preston.model.RefNodeFactory.toLiteral;
 import static bio.guoda.preston.model.RefNodeFactory.toStatement;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.StringEndsWith.endsWith;
-import static org.hamcrest.core.StringStartsWith.startsWith;
 
 public class RegistryReaderBHLTest {
 
@@ -33,8 +29,8 @@ public class RegistryReaderBHLTest {
         ArrayList<Quad> nodes = new ArrayList<>();
         RegistryReaderBHL registryReader = new RegistryReaderBHL(TestUtil.getTestBlobStore(), nodes::add);
         registryReader.on(toStatement(Seeds.BHL, WAS_ASSOCIATED_WITH, toIRI("http://example.org/someActivity")));
-        Assert.assertThat(nodes.size(), is(5));
-        assertThat(getVersionSource(nodes.get(4)).getIRIString(), is("https://www.biodiversitylibrary.org/data/item.txt"));
+        Assert.assertThat(nodes.size(), is(6));
+        assertThat(getVersionSource(nodes.get(5)).getIRIString(), is("https://www.biodiversitylibrary.org/data/item.txt"));
     }
 
     @Test
@@ -73,7 +69,7 @@ public class RegistryReaderBHLTest {
 
         registryReader.on(firstPage);
 
-        Assert.assertThat(nodes.size(), is(36));
+        Assert.assertThat(nodes.size(), is(37));
         Quad mimeType = nodes.get(nodes.size() - 2);
         assertThat(mimeType.getSubject().toString(), is("<https://archive.org/download/mobot31753002306964/mobot31753002306964_djvu.txt>"));
         assertThat(mimeType.getPredicate().toString(), is("<http://purl.org/dc/elements/1.1/format>"));

--- a/src/test/java/bio/guoda/preston/process/RegistryReaderBioCASETest.java
+++ b/src/test/java/bio/guoda/preston/process/RegistryReaderBioCASETest.java
@@ -46,8 +46,8 @@ public class RegistryReaderBioCASETest {
     public void onSeed() {
         RDFTerm bla = toLiteral("bla");
         registryReader.on(toStatement(Seeds.BIOCASE, WAS_ASSOCIATED_WITH, bla));
-        Assert.assertThat(nodes.size(), is(4));
-        assertThat(((IRI) getVersionSource(nodes.get(3))).getIRIString(), is(RegistryReaderBioCASE.BIOCASE_REGISTRY_ENDPOINT));
+        Assert.assertThat(nodes.size(), is(5));
+        assertThat(((IRI) getVersionSource(nodes.get(4))).getIRIString(), is(RegistryReaderBioCASE.BIOCASE_REGISTRY_ENDPOINT));
     }
 
     @Test
@@ -97,16 +97,16 @@ public class RegistryReaderBioCASETest {
         registryReader.on(toStatement(toIRI(RegistryReaderBioCASE.BIOCASE_REGISTRY_ENDPOINT), HAS_VERSION, refNode));
 
         assertFalse(nodes.isEmpty());
-        assertThat(nodes.get(0).getSubject(), is(refNode));
-        assertThat(nodes.get(0).getPredicate(), is(RefNodeConstants.HAD_MEMBER));
-        assertThat(nodes.get(0).getObject().toString(), is("<http://ww3.bgbm.org/biocase/pywrapper.cgi?dsa=GFBio_ColiFauna&inventory=1>"));
+        assertThat(nodes.get(1).getSubject(), is(refNode));
+        assertThat(nodes.get(1).getPredicate(), is(RefNodeConstants.HAD_MEMBER));
+        assertThat(nodes.get(1).getObject().toString(), is("<http://ww3.bgbm.org/biocase/pywrapper.cgi?dsa=GFBio_ColiFauna&inventory=1>"));
 
-        assertThat(nodes.get(1).getObject().toString(), is("\"text/xml\""));
-        assertThat(nodes.get(1).getPredicate(), is(RefNodeConstants.HAS_FORMAT));
-        assertThat(nodes.get(1).getSubject().toString(), is("<http://ww3.bgbm.org/biocase/pywrapper.cgi?dsa=GFBio_ColiFauna&inventory=1>"));
-
-        assertThat(nodes.get(2).getPredicate(), is(HAS_VERSION));
+        assertThat(nodes.get(2).getObject().toString(), is("\"text/xml\""));
+        assertThat(nodes.get(2).getPredicate(), is(RefNodeConstants.HAS_FORMAT));
         assertThat(nodes.get(2).getSubject().toString(), is("<http://ww3.bgbm.org/biocase/pywrapper.cgi?dsa=GFBio_ColiFauna&inventory=1>"));
+
+        assertThat(nodes.get(3).getPredicate(), is(HAS_VERSION));
+        assertThat(nodes.get(3).getSubject().toString(), is("<http://ww3.bgbm.org/biocase/pywrapper.cgi?dsa=GFBio_ColiFauna&inventory=1>"));
 
     }
 
@@ -137,17 +137,17 @@ public class RegistryReaderBioCASETest {
 
         registryReader.on(toStatement(toIRI("http://something/pywrapper.cgi?dsa="), HAS_VERSION, someHash));
 
-        assertThat(nodes.size(), is(3));
-        assertThat(nodes.get(0).getPredicate(), is(RefNodeConstants.HAD_MEMBER));
-        assertThat(nodes.get(0).getSubject(), is(someHash));
+        assertThat(nodes.size(), is(4));
+        assertThat(nodes.get(1).getPredicate(), is(RefNodeConstants.HAD_MEMBER));
+        assertThat(nodes.get(1).getSubject(), is(someHash));
         String zipArchive = "<http://ww3.bgbm.org/biocase/downloads/GFBio_ColiFauna/Coleoptera%20observations%20in%20orchards%20of%20South%20Western%20Germany.ABCD_2.06.zip>";
-        assertThat(nodes.get(0).getObject().toString(), is(zipArchive));
+        assertThat(nodes.get(1).getObject().toString(), is(zipArchive));
 
-        assertThat(nodes.get(1).getPredicate(), is(RefNodeConstants.HAS_FORMAT));
-        assertThat(nodes.get(1).getSubject().toString(), is(zipArchive));
-        assertThat(nodes.get(1).getObject().toString(), is("\"application/abcda\""));
+        assertThat(nodes.get(2).getPredicate(), is(RefNodeConstants.HAS_FORMAT));
+        assertThat(nodes.get(2).getSubject().toString(), is(zipArchive));
+        assertThat(nodes.get(2).getObject().toString(), is("\"application/abcda\""));
 
-        assertThat(getVersionSource(nodes.get(2)).getIRIString(), is("http://ww3.bgbm.org/biocase/downloads/GFBio_ColiFauna/Coleoptera%20observations%20in%20orchards%20of%20South%20Western%20Germany.ABCD_2.06.zip"));
+        assertThat(getVersionSource(nodes.get(3)).getIRIString(), is("http://ww3.bgbm.org/biocase/downloads/GFBio_ColiFauna/Coleoptera%20observations%20in%20orchards%20of%20South%20Western%20Germany.ABCD_2.06.zip"));
     }
 
     @Test

--- a/src/test/java/bio/guoda/preston/process/RegistryReaderDataONETest.java
+++ b/src/test/java/bio/guoda/preston/process/RegistryReaderDataONETest.java
@@ -3,9 +3,8 @@ package bio.guoda.preston.process;
 import bio.guoda.preston.Seeds;
 import bio.guoda.preston.store.TestUtil;
 import org.apache.commons.rdf.api.IRI;
-import org.apache.commons.rdf.api.RDFTerm;
-import org.apache.commons.rdf.api.Triple;
 import org.apache.commons.rdf.api.Quad;
+import org.apache.commons.rdf.api.RDFTerm;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -15,8 +14,11 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static bio.guoda.preston.RefNodeConstants.HAD_MEMBER;
+import static bio.guoda.preston.RefNodeConstants.HAS_FORMAT;
 import static bio.guoda.preston.RefNodeConstants.HAS_VERSION;
 import static bio.guoda.preston.RefNodeConstants.WAS_ASSOCIATED_WITH;
+import static bio.guoda.preston.TripleMatcher.hasTriple;
 import static bio.guoda.preston.model.RefNodeFactory.getVersionSource;
 import static bio.guoda.preston.model.RefNodeFactory.toIRI;
 import static bio.guoda.preston.model.RefNodeFactory.toLiteral;
@@ -36,8 +38,8 @@ public class RegistryReaderDataONETest {
         ArrayList<Quad> nodes = new ArrayList<>();
         RegistryReaderDataONE reader = new RegistryReaderDataONE(TestUtil.getTestBlobStore(), nodes::add);
         reader.on(toStatement(Seeds.DATA_ONE, WAS_ASSOCIATED_WITH, toIRI("http://example.org/someActivity")));
-        Assert.assertThat(nodes.size(), is(6));
-        assertThat(getVersionSource(nodes.get(5)).getIRIString(), is(FIRST_PAGE));
+        Assert.assertThat(nodes.size(), is(7));
+        assertThat(getVersionSource(nodes.get(6)).getIRIString(), is(FIRST_PAGE));
     }
 
     @Test
@@ -48,7 +50,7 @@ public class RegistryReaderDataONETest {
         reader.on(toStatement(toIRI(FIRST_PAGE),
                 HAS_VERSION,
                 toIRI("https://some")));
-        assertThat(nodes.size(), is(0));
+        assertThat(nodes.size(), is(1));
     }
 
     @Test
@@ -76,7 +78,7 @@ public class RegistryReaderDataONETest {
 
         reader.on(firstPage);
 
-        Assert.assertThat(nodes.size(), is(43));
+        Assert.assertThat(nodes.size(), is(44));
         Quad secondPage = nodes.get(nodes.size() - 1);
         assertThat(getVersionSource(secondPage).toString(), is("<http://cn.dataone.org/cn/v2/query/solr/?q=formatId:eml*+AND+-obsoletedBy:*&fl=identifier,dataUrl&wt=json&start=1000&rows=1000>"));
     }
@@ -98,7 +100,7 @@ public class RegistryReaderDataONETest {
 
         reader.on(firstPage);
 
-        Assert.assertThat(nodes.size(), is(43));
+        Assert.assertThat(nodes.size(), is(44));
         Quad secondPage = nodes.get(nodes.size() - 1);
         assertThat(secondPage.toString(), startsWith("<http://cn.dataone.org/cn/v2/query/solr/?q=formatId:eml*+AND+-obsoletedBy:*&fl=identifier,dataUrl&wt=json&start=1000&rows=1000> <http://purl.org/pav/hasVersion> _:"));
     }
@@ -119,7 +121,7 @@ public class RegistryReaderDataONETest {
 
         reader.on(firstPage);
 
-        Assert.assertThat(nodes.size(), is(43));
+        Assert.assertThat(nodes.size(), is(44));
         Quad secondPage = nodes.get(nodes.size() - 1);
         assertThat(getVersionSource(secondPage).toString(), is("<http://cn.dataone.org/cn/v2/query/solr/?q=formatId:eml*+AND+-obsoletedBy:*&fl=identifier,dataUrl&wt=json&start=1000&rows=1000>"));
     }
@@ -139,15 +141,17 @@ public class RegistryReaderDataONETest {
 
         reader.on(firstPage);
 
-        Assert.assertThat(nodes.size(), is(20));
-        Quad identifierMemberStatement = nodes.get(1);
-        assertThat(identifierMemberStatement.toString(), is("<aekos.org.au/collection/nsw.gov.au/nsw_atlas/vis_flora_module/NOMBIN.20150515> <http://www.w3.org/ns/prov#hadMember> <https://dataone.tern.org.au/mn/v2/object/aekos.org.au%2Fcollection%2Fnsw.gov.au%2Fnsw_atlas%2Fvis_flora_module%2FNOMBIN.20150515> ."));
-        Quad locationType = nodes.get(2);
-        assertThat(locationType.toString(), is("<https://dataone.tern.org.au/mn/v2/object/aekos.org.au%2Fcollection%2Fnsw.gov.au%2Fnsw_atlas%2Fvis_flora_module%2FNOMBIN.20150515> <http://purl.org/dc/elements/1.1/format> \"application/eml\" ."));
-        Quad locationVersion = nodes.get(3);
-        assertThat(locationVersion.toString(), startsWith("<https://dataone.tern.org.au/mn/v2/object/aekos.org.au%2Fcollection%2Fnsw.gov.au%2Fnsw_atlas%2Fvis_flora_module%2FNOMBIN.20150515> <http://purl.org/pav/hasVersion> _:"));
-        Quad nodeIdentifierMemberStatement = nodes.get(4);
-        assertThat(nodeIdentifierMemberStatement.toString(), is("<urn:node:CN> <http://www.w3.org/ns/prov#hadMember> <aekos.org.au/collection/nsw.gov.au/nsw_atlas/vis_flora_module/NOMBIN.20150515> ."));
+        Assert.assertThat(nodes.size(), is(21));
+        Quad identifierMemberStatement = nodes.get(2);
+        assertThat(identifierMemberStatement, hasTriple(toStatement(toIRI("aekos.org.au/collection/nsw.gov.au/nsw_atlas/vis_flora_module/NOMBIN.20150515"), HAD_MEMBER, toIRI("https://dataone.tern.org.au/mn/v2/object/aekos.org.au%2Fcollection%2Fnsw.gov.au%2Fnsw_atlas%2Fvis_flora_module%2FNOMBIN.20150515"))));
+        Quad locationType = nodes.get(3);
+        assertThat(locationType, hasTriple(toStatement(toIRI("https://dataone.tern.org.au/mn/v2/object/aekos.org.au%2Fcollection%2Fnsw.gov.au%2Fnsw_atlas%2Fvis_flora_module%2FNOMBIN.20150515"), HAS_FORMAT, toLiteral("application/eml"))));
+        Quad locationVersion = nodes.get(4);
+        assertThat(locationVersion.getSubject(), is(toIRI("https://dataone.tern.org.au/mn/v2/object/aekos.org.au%2Fcollection%2Fnsw.gov.au%2Fnsw_atlas%2Fvis_flora_module%2FNOMBIN.20150515")));
+        assertThat(locationVersion.getPredicate(), is(HAS_VERSION));
+        assertThat(locationVersion.getObject().toString(), startsWith("_:"));
+        Quad nodeIdentifierMemberStatement = nodes.get(5);
+        assertThat(nodeIdentifierMemberStatement, hasTriple(toStatement(toIRI("urn:node:CN"), HAD_MEMBER, toIRI("aekos.org.au/collection/nsw.gov.au/nsw_atlas/vis_flora_module/NOMBIN.20150515"))));
     }
 
     @Test

--- a/src/test/java/bio/guoda/preston/process/RegistryReaderGBIFTest.java
+++ b/src/test/java/bio/guoda/preston/process/RegistryReaderGBIFTest.java
@@ -16,7 +16,9 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
+import static bio.guoda.preston.MimeTypes.MIME_TYPE_JSON;
 import static bio.guoda.preston.RefNodeConstants.*;
+import static bio.guoda.preston.TripleMatcher.hasTriple;
 import static bio.guoda.preston.model.RefNodeFactory.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -32,9 +34,9 @@ public class RegistryReaderGBIFTest {
         ArrayList<Quad> nodes = new ArrayList<>();
         RegistryReaderGBIF registryReaderGBIF = new RegistryReaderGBIF(TestUtil.getTestBlobStore(), nodes::add);
         registryReaderGBIF.on(toStatement(Seeds.GBIF, WAS_ASSOCIATED_WITH, toIRI("http://example.org/someActivity")));
-        assertThat(new HashSet<>(nodes).size(), is(5));
-        Assert.assertThat(nodes.size(), is(5));
-        assertThat(getVersionSource(nodes.get(4)).getIRIString(), is("https://api.gbif.org/v1/dataset"));
+        assertThat(new HashSet<>(nodes).size(), is(6));
+        Assert.assertThat(nodes.size(), is(6));
+        assertThat(getVersionSource(nodes.get(5)).getIRIString(), is("https://api.gbif.org/v1/dataset"));
     }
 
     @Test
@@ -45,7 +47,7 @@ public class RegistryReaderGBIFTest {
         registryReaderGBIF.on(toStatement(toIRI("https://api.gbif.org/v1/dataset"),
                 HAS_VERSION,
                 toIRI("https://some")));
-        assertThat(nodes.size(), is(0));
+        assertThat(nodes.size(), is(1));
     }
 
     @Test
@@ -73,10 +75,10 @@ public class RegistryReaderGBIFTest {
 
         registryReaderGBIF.on(firstPage);
 
-        Assert.assertThat(nodes.size(), is(60973));
-        assertThat(nodes.get(17-1).toString(), is("<https://api.gbif.org/v1/dataset?offset=2&limit=2> <http://purl.org/pav/createdBy> <https://gbif.org> ."));
-        assertThat(nodes.get(18-1).toString(), is("<https://api.gbif.org/v1/dataset?offset=2&limit=2> <http://purl.org/dc/elements/1.1/format> \"application/json\" ."));
-        Quad secondPage = nodes.get(19 - 1);
+        Assert.assertThat(nodes.size(), is(60974));
+        assertThat(nodes.get(18 - 1), hasTriple(toStatement(toIRI("https://api.gbif.org/v1/dataset?offset=2&limit=2"), CREATED_BY, toIRI("https://gbif.org"))));
+        assertThat(nodes.get(19 - 1), hasTriple(toStatement(toIRI("https://api.gbif.org/v1/dataset?offset=2&limit=2"), HAS_FORMAT, toLiteral(MIME_TYPE_JSON))));
+        Quad secondPage = nodes.get(20 - 1);
         assertThat(getVersionSource(secondPage).toString(), is("<https://api.gbif.org/v1/dataset?offset=2&limit=2>"));
         Quad lastPage = nodes.get(nodes.size() - 1);
         assertThat(getVersionSource(lastPage).toString(), is("<https://api.gbif.org/v1/dataset?offset=40638&limit=2>"));
@@ -98,7 +100,7 @@ public class RegistryReaderGBIFTest {
 
         registryReaderGBIF.on(firstPage);
 
-        Assert.assertThat(nodes.size(), is(4));
+        Assert.assertThat(nodes.size(), is(5));
         Quad lastItem = nodes.get(nodes.size() - 1);
         assertThat(getVersionSource(lastItem).toString(), is("<https://api.gbif.org/v1/dataset/b7010c1b-8013-4a3c-a43b-4309a91f9629>"));
     }
@@ -119,7 +121,7 @@ public class RegistryReaderGBIFTest {
 
         registryReaderGBIF.on(firstPage);
 
-        Assert.assertThat(nodes.size(), is(40));
+        Assert.assertThat(nodes.size(), is(41));
         Quad lastItem = nodes.get(nodes.size() - 1);
         assertThat(getVersionSource(lastItem).toString(), is("<https://api.gbif.org/v1/dataset/663199f1-3528-4289-8069-d27552f62f10>"));
     }
@@ -140,8 +142,8 @@ public class RegistryReaderGBIFTest {
 
         registryReaderGBIF.on(firstPage);
 
-        Assert.assertThat(nodes.size(), is(60973));
-        Quad secondPage = nodes.get(19 - 1);
+        Assert.assertThat(nodes.size(), is(60974));
+        Quad secondPage = nodes.get(20 - 1);
         assertThat(getVersionSource(secondPage).toString(), is("<https://api.gbif.org/v1/dataset/search?q=plant&amp;publishingCountry=AR&offset=2&limit=2>"));
         Quad lastPage = nodes.get(nodes.size() - 1);
         assertThat(getVersionSource(lastPage).toString(), is("<https://api.gbif.org/v1/dataset/search?q=plant&amp;publishingCountry=AR&offset=40638&limit=2>"));
@@ -163,7 +165,7 @@ public class RegistryReaderGBIFTest {
 
         registryReaderGBIF.on(firstPage);
 
-        Assert.assertThat(nodes.size(), is(5));
+        Assert.assertThat(nodes.size(), is(6));
         Quad secondPage = nodes.get(nodes.size() - 1);
         assertThat(getVersionSource(secondPage).toString(), is("<http://plazi.cs.umb.edu/GgServer/dwca/2924FFB8FFC7C76B4B0B503BFFD8D973.zip>"));
     }

--- a/src/test/java/bio/guoda/preston/process/RegistryReaderIDigBioTest.java
+++ b/src/test/java/bio/guoda/preston/process/RegistryReaderIDigBioTest.java
@@ -5,8 +5,8 @@ import bio.guoda.preston.model.RefNodeFactory;
 import bio.guoda.preston.store.BlobStore;
 import bio.guoda.preston.store.TestUtil;
 import org.apache.commons.rdf.api.IRI;
-import org.apache.commons.rdf.api.RDFTerm;
 import org.apache.commons.rdf.api.Quad;
+import org.apache.commons.rdf.api.RDFTerm;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -29,7 +29,7 @@ public class RegistryReaderIDigBioTest {
         RegistryReaderIDigBio reader = new RegistryReaderIDigBio(TestUtil.getTestBlobStore(), nodes::add);
         RDFTerm bla = RefNodeFactory.toLiteral("bla");
         reader.on(RefNodeFactory.toStatement(Seeds.IDIGBIO, WAS_ASSOCIATED_WITH, bla));
-        assertThat(nodes.size(), is(5));
+        assertThat(nodes.size(), is(6));
     }
 
     @Test

--- a/src/test/java/bio/guoda/preston/process/RegistryReaderOBISTest.java
+++ b/src/test/java/bio/guoda/preston/process/RegistryReaderOBISTest.java
@@ -33,8 +33,8 @@ public class RegistryReaderOBISTest {
         ArrayList<Quad> nodes = new ArrayList<>();
         RegistryReaderOBIS registryReader = new RegistryReaderOBIS(TestUtil.getTestBlobStore(), nodes::add);
         registryReader.on(toStatement(Seeds.OBIS, WAS_ASSOCIATED_WITH, toIRI("http://example.org/someActivity")));
-        Assert.assertThat(nodes.size(), is(5));
-        assertThat(getVersionSource(nodes.get(4)).getIRIString(), is("https://api.obis.org/v3/dataset"));
+        Assert.assertThat(nodes.size(), is(6));
+        assertThat(getVersionSource(nodes.get(5)).getIRIString(), is("https://api.obis.org/v3/dataset"));
     }
 
     @Test

--- a/src/test/java/bio/guoda/preston/process/RegistryReaderRSSTest.java
+++ b/src/test/java/bio/guoda/preston/process/RegistryReaderRSSTest.java
@@ -46,7 +46,7 @@ public class RegistryReaderRSSTest {
         StatementListener registryReader = new RegistryReaderRSS(blobStore, nodes::add);
 
         registryReader.on(toStatement(toIRI("daisyduck"), HAS_VERSION, toIRI("somehash")));
-        assertThat(nodes.size(), is(1849));
+        assertThat(nodes.size(), is(1850));
     }
 
     @Test

--- a/src/test/java/bio/guoda/preston/store/ArchiverTest.java
+++ b/src/test/java/bio/guoda/preston/store/ArchiverTest.java
@@ -123,7 +123,9 @@ public class ArchiverTest {
 
     @Test
     public void includeGenerationActivity() throws IOException {
-        Quad statement = toStatement(toIRI(URI.create("http://some")),
+        ActivityContext testCrawlContext = TestUtil.getTestCrawlContext();
+        Quad statement = toStatement(testCrawlContext.getActivity(),
+                toIRI(URI.create("http://some")),
                 HAS_VERSION,
                 toBlank());
 
@@ -140,7 +142,6 @@ public class ArchiverTest {
 
         StatementStoreImpl versionStore = new StatementStoreImpl(testKeyValueStore);
 
-        ActivityContext testCrawlContext = TestUtil.getTestCrawlContext();
         Archiver relationStore = new Archiver(
                 dereferencer,
                 testCrawlContext,


### PR DESCRIPTION
New activities are now generated for parsing events and `wasInformedBy` statements document chains of cause and effect across activities. If all looks good, #33 and #41 should be closed.

Example output below. Note the connections between graph names and `wasInformedBy` statements.
```shell
$ preston track "http://ipt.vertnet.org:8080/ipt/rss.do"
$ preston ls | head -50
<https://preston.guoda.bio> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#SoftwareAgent> <7fecd486-69bf-4bd0-8178-eeabe8891785> .
<https://preston.guoda.bio> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Agent> <7fecd486-69bf-4bd0-8178-eeabe8891785> .
<https://preston.guoda.bio> <http://purl.org/dc/terms/description> "Preston is a software program that finds, archives and provides access to biodiversity datasets."@en <7fecd486-69bf-4bd0-8178-eeabe8891785> .
<7fecd486-69bf-4bd0-8178-eeabe8891785> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Activity> <7fecd486-69bf-4bd0-8178-eeabe8891785> .
<7fecd486-69bf-4bd0-8178-eeabe8891785> <http://purl.org/dc/terms/description> "A crawl event that discovers biodiversity archives."@en <7fecd486-69bf-4bd0-8178-eeabe8891785> .
<7fecd486-69bf-4bd0-8178-eeabe8891785> <http://www.w3.org/ns/prov#startedAtTime> "2020-03-21T20:08:59.544Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> <7fecd486-69bf-4bd0-8178-eeabe8891785> .
<7fecd486-69bf-4bd0-8178-eeabe8891785> <http://www.w3.org/ns/prov#wasStartedBy> <https://preston.guoda.bio> <7fecd486-69bf-4bd0-8178-eeabe8891785> .
<https://doi.org/10.5281/zenodo.1410543> <http://www.w3.org/ns/prov#usedBy> <7fecd486-69bf-4bd0-8178-eeabe8891785> <7fecd486-69bf-4bd0-8178-eeabe8891785> .
<https://doi.org/10.5281/zenodo.1410543> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://purl.org/dc/dcmitype/Software> <7fecd486-69bf-4bd0-8178-eeabe8891785> .
<https://doi.org/10.5281/zenodo.1410543> <http://purl.org/dc/terms/bibliographicCitation> "Jorrit Poelen, Icaro Alzuru, & Michael Elliott. 2019. Preston: a biodiversity dataset tracker (Version 0.0.1-SNAPSHOT) [Software]. Zenodo. http://doi.org/10.5281/zenodo.1410543"@en <7fecd486-69bf-4bd0-8178-eeabe8891785> .
<0659a54f-b713-4f86-a917-5be166a14110> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Entity> <7fecd486-69bf-4bd0-8178-eeabe8891785> .
<0659a54f-b713-4f86-a917-5be166a14110> <http://purl.org/dc/terms/description> "A biodiversity dataset graph archive."@en <7fecd486-69bf-4bd0-8178-eeabe8891785> .
<hash://sha256/e8e77bf19f00fbd28b0608b0c0507f642b2f622c737175819eae253fbb9dc1ac> <http://www.w3.org/ns/prov#wasGeneratedBy> <58412d96-482d-487b-9648-d5732781675d> <58412d96-482d-487b-9648-d5732781675d> .
<hash://sha256/e8e77bf19f00fbd28b0608b0c0507f642b2f622c737175819eae253fbb9dc1ac> <http://www.w3.org/ns/prov#qualifiedGeneration> <58412d96-482d-487b-9648-d5732781675d> <58412d96-482d-487b-9648-d5732781675d> .
<58412d96-482d-487b-9648-d5732781675d> <http://www.w3.org/ns/prov#generatedAtTime> "2020-03-21T20:09:00.712Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> <58412d96-482d-487b-9648-d5732781675d> .
<58412d96-482d-487b-9648-d5732781675d> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Generation> <58412d96-482d-487b-9648-d5732781675d> .
<58412d96-482d-487b-9648-d5732781675d> <http://www.w3.org/ns/prov#wasInformedBy> <7fecd486-69bf-4bd0-8178-eeabe8891785> <58412d96-482d-487b-9648-d5732781675d> .
<58412d96-482d-487b-9648-d5732781675d> <http://www.w3.org/ns/prov#used> <http://ipt.vertnet.org:8080/ipt/rss.do> <58412d96-482d-487b-9648-d5732781675d> .
<http://ipt.vertnet.org:8080/ipt/rss.do> <http://purl.org/pav/hasVersion> <hash://sha256/e8e77bf19f00fbd28b0608b0c0507f642b2f622c737175819eae253fbb9dc1ac> <58412d96-482d-487b-9648-d5732781675d> .
<42ecab64-b575-46d3-8064-e590946064e9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Activity> <42ecab64-b575-46d3-8064-e590946064e9> .
<42ecab64-b575-46d3-8064-e590946064e9> <http://www.w3.org/ns/prov#wasInformedBy> <58412d96-482d-487b-9648-d5732781675d> <42ecab64-b575-46d3-8064-e590946064e9> .
<hash://sha256/e8e77bf19f00fbd28b0608b0c0507f642b2f622c737175819eae253fbb9dc1ac> <http://www.w3.org/ns/prov#hadMember> <http://ipt.vertnet.org:8080/ipt/resource?id=dmns_bird_ggbn/v1.9> <42ecab64-b575-46d3-8064-e590946064e9> .
<http://ipt.vertnet.org:8080/ipt/resource?id=dmns_bird_ggbn/v1.9> <http://www.w3.org/ns/prov#hadMember> <http://ipt.vertnet.org:8080/ipt/eml.do?r=dmns_bird_ggbn> <42ecab64-b575-46d3-8064-e590946064e9> .
<http://ipt.vertnet.org:8080/ipt/eml.do?r=dmns_bird_ggbn> <http://purl.org/dc/elements/1.1/format> "application/eml" <42ecab64-b575-46d3-8064-e590946064e9> .
<hash://sha256/5fdf4bb4fe6a02fcc0d20a297446054164b3f585185654b1c6e9a6434b1e5d3b> <http://www.w3.org/ns/prov#wasGeneratedBy> <7989e193-47ed-4147-929a-e24ec3856047> <7989e193-47ed-4147-929a-e24ec3856047> .
<hash://sha256/5fdf4bb4fe6a02fcc0d20a297446054164b3f585185654b1c6e9a6434b1e5d3b> <http://www.w3.org/ns/prov#qualifiedGeneration> <7989e193-47ed-4147-929a-e24ec3856047> <7989e193-47ed-4147-929a-e24ec3856047> .
<7989e193-47ed-4147-929a-e24ec3856047> <http://www.w3.org/ns/prov#generatedAtTime> "2020-03-21T20:09:01.134Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> <7989e193-47ed-4147-929a-e24ec3856047> .
<7989e193-47ed-4147-929a-e24ec3856047> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Generation> <7989e193-47ed-4147-929a-e24ec3856047> .
<7989e193-47ed-4147-929a-e24ec3856047> <http://www.w3.org/ns/prov#wasInformedBy> <42ecab64-b575-46d3-8064-e590946064e9> <7989e193-47ed-4147-929a-e24ec3856047> .
<7989e193-47ed-4147-929a-e24ec3856047> <http://www.w3.org/ns/prov#used> <http://ipt.vertnet.org:8080/ipt/eml.do?r=dmns_bird_ggbn> <7989e193-47ed-4147-929a-e24ec3856047> .
<http://ipt.vertnet.org:8080/ipt/eml.do?r=dmns_bird_ggbn> <http://purl.org/pav/hasVersion> <hash://sha256/5fdf4bb4fe6a02fcc0d20a297446054164b3f585185654b1c6e9a6434b1e5d3b> <7989e193-47ed-4147-929a-e24ec3856047> .
<http://ipt.vertnet.org:8080/ipt/resource?id=dmns_bird_ggbn/v1.9> <http://www.w3.org/ns/prov#hadMember> <http://ipt.vertnet.org:8080/ipt/archive.do?r=dmns_bird_ggbn> <42ecab64-b575-46d3-8064-e590946064e9> .
<http://ipt.vertnet.org:8080/ipt/archive.do?r=dmns_bird_ggbn> <http://purl.org/dc/elements/1.1/format> "application/dwca" <42ecab64-b575-46d3-8064-e590946064e9> .
<hash://sha256/5e91f618302e6d7516a3e3eeaa283400c693a55ad76dbb0f947cee3fc6749e57> <http://www.w3.org/ns/prov#wasGeneratedBy> <260734cc-e8f1-42ba-bc43-e87f5609cef9> <260734cc-e8f1-42ba-bc43-e87f5609cef9> .
<hash://sha256/5e91f618302e6d7516a3e3eeaa283400c693a55ad76dbb0f947cee3fc6749e57> <http://www.w3.org/ns/prov#qualifiedGeneration> <260734cc-e8f1-42ba-bc43-e87f5609cef9> <260734cc-e8f1-42ba-bc43-e87f5609cef9> .
<260734cc-e8f1-42ba-bc43-e87f5609cef9> <http://www.w3.org/ns/prov#generatedAtTime> "2020-03-21T20:09:02.048Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> <260734cc-e8f1-42ba-bc43-e87f5609cef9> .
<260734cc-e8f1-42ba-bc43-e87f5609cef9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Generation> <260734cc-e8f1-42ba-bc43-e87f5609cef9> .
<260734cc-e8f1-42ba-bc43-e87f5609cef9> <http://www.w3.org/ns/prov#wasInformedBy> <42ecab64-b575-46d3-8064-e590946064e9> <260734cc-e8f1-42ba-bc43-e87f5609cef9> .
<260734cc-e8f1-42ba-bc43-e87f5609cef9> <http://www.w3.org/ns/prov#used> <http://ipt.vertnet.org:8080/ipt/archive.do?r=dmns_bird_ggbn> <260734cc-e8f1-42ba-bc43-e87f5609cef9> .
<http://ipt.vertnet.org:8080/ipt/archive.do?r=dmns_bird_ggbn> <http://purl.org/pav/hasVersion> <hash://sha256/5e91f618302e6d7516a3e3eeaa283400c693a55ad76dbb0f947cee3fc6749e57> <260734cc-e8f1-42ba-bc43-e87f5609cef9> .
<hash://sha256/e8e77bf19f00fbd28b0608b0c0507f642b2f622c737175819eae253fbb9dc1ac> <http://www.w3.org/ns/prov#hadMember> <http://ipt.vertnet.org:8080/ipt/resource?id=msb_para_ggbn/v1.9> <42ecab64-b575-46d3-8064-e590946064e9> .
<http://ipt.vertnet.org:8080/ipt/resource?id=msb_para_ggbn/v1.9> <http://www.w3.org/ns/prov#hadMember> <http://ipt.vertnet.org:8080/ipt/eml.do?r=msb_para_ggbn> <42ecab64-b575-46d3-8064-e590946064e9> .
<http://ipt.vertnet.org:8080/ipt/eml.do?r=msb_para_ggbn> <http://purl.org/dc/elements/1.1/format> "application/eml" <42ecab64-b575-46d3-8064-e590946064e9> .
<hash://sha256/349a0937d43a545fbd21af43a61ff0677e44befb262ccfe9119b5dbdfc17aaff> <http://www.w3.org/ns/prov#wasGeneratedBy> <215a0533-dbdb-457d-be22-2f8c780c1fbe> <215a0533-dbdb-457d-be22-2f8c780c1fbe> .
<hash://sha256/349a0937d43a545fbd21af43a61ff0677e44befb262ccfe9119b5dbdfc17aaff> <http://www.w3.org/ns/prov#qualifiedGeneration> <215a0533-dbdb-457d-be22-2f8c780c1fbe> <215a0533-dbdb-457d-be22-2f8c780c1fbe> .
<215a0533-dbdb-457d-be22-2f8c780c1fbe> <http://www.w3.org/ns/prov#generatedAtTime> "2020-03-21T20:09:02.157Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> <215a0533-dbdb-457d-be22-2f8c780c1fbe> .
<215a0533-dbdb-457d-be22-2f8c780c1fbe> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Generation> <215a0533-dbdb-457d-be22-2f8c780c1fbe> .
<215a0533-dbdb-457d-be22-2f8c780c1fbe> <http://www.w3.org/ns/prov#wasInformedBy> <42ecab64-b575-46d3-8064-e590946064e9> <215a0533-dbdb-457d-be22-2f8c780c1fbe> .
<215a0533-dbdb-457d-be22-2f8c780c1fbe> <http://www.w3.org/ns/prov#used> <http://ipt.vertnet.org:8080/ipt/eml.do?r=msb_para_ggbn> <215a0533-dbdb-457d-be22-2f8c780c1fbe> .
<http://ipt.vertnet.org:8080/ipt/eml.do?r=msb_para_ggbn> <http://purl.org/pav/hasVersion> <hash://sha256/349a0937d43a545fbd21af43a61ff0677e44befb262ccfe9119b5dbdfc17aaff> <215a0533-dbdb-457d-be22-2f8c780c1fbe> .
```
```shell
$ preston ls | grep "wasInformedBy" | head
<58412d96-482d-487b-9648-d5732781675d> <http://www.w3.org/ns/prov#wasInformedBy> <7fecd486-69bf-4bd0-8178-eeabe8891785> <58412d96-482d-487b-9648-d5732781675d> .
<42ecab64-b575-46d3-8064-e590946064e9> <http://www.w3.org/ns/prov#wasInformedBy> <58412d96-482d-487b-9648-d5732781675d> <42ecab64-b575-46d3-8064-e590946064e9> .
<7989e193-47ed-4147-929a-e24ec3856047> <http://www.w3.org/ns/prov#wasInformedBy> <42ecab64-b575-46d3-8064-e590946064e9> <7989e193-47ed-4147-929a-e24ec3856047> .
<260734cc-e8f1-42ba-bc43-e87f5609cef9> <http://www.w3.org/ns/prov#wasInformedBy> <42ecab64-b575-46d3-8064-e590946064e9> <260734cc-e8f1-42ba-bc43-e87f5609cef9> .
<215a0533-dbdb-457d-be22-2f8c780c1fbe> <http://www.w3.org/ns/prov#wasInformedBy> <42ecab64-b575-46d3-8064-e590946064e9> <215a0533-dbdb-457d-be22-2f8c780c1fbe> .
```