### PR TITLE
fix text mining example

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,9 +245,9 @@ The Ecological Metadata Language (EML) files contain citations, and your biodive
 
 ```console
 # first make a list of all the emls
-preston ls | grep application/eml | cut -f1 > emls.txt
+preston ls | grep application/eml | cut -d ' ' -f1 | tr -d '<>' > emls.txt
 # then 
-preston ls -l tsv | grep -f emls.tsv | grep "Version" | grep hash | cut -f3 | preston get | grep citation | sed 's/<[^>]*>//g' > citations.txt
+preston ls -l tsv | grep -f emls.txt | grep "Version" | grep hash | cut -f3 | preston get | grep citation | sed 's/<[^>]*>//g' > citations.txt
 head citations.txt
             HW Jackson C, Ochieng J, Musila S, Navarro R, Kanga E (2018): A Checklist of the Mammals of Arabuko-Sokoke Forest, Kenya, 2018. v1.0. A Rocha Kenya. Dataset/Checklist. http://ipt.museums.or.ke/ipt/resource?r=asfmammals&amp;v=1.0
             Adda M., Sanou L., Bori H., 2018. Specimens d&apos;herbier de la flore du Niger. Données d&apos;occurrence publiées dans le cadre du Prjet BID Régional. CNSF-Niger  					


### PR DESCRIPTION
emls.txt was then called as emls.tsv.

Also, I had to add intermediate steps to get the correct emls.txt file:
`preston ls | grep application/eml | cut -d ' ' -f 1 | tr -d '<>' > emls.tsv`
which produces
```
http://lucina.inbio.ac.cr/IPT-SSTN/eml.do?r=p6r22
https://gbif.laji.fi/eml/HR.2309.zip
http://data.freshwaterbiodiversity.eu/ipt/eml.do?r=bfe_105
http://ipt.env.duke.edu/eml.do?r=zd_2043
```
instead of 
`preston ls | grep application/eml | cut -f 1 > emls.tsv`
which produces
```
<http://lucina.inbio.ac.cr/IPT-SSTN/eml.do?r=p6r22> <http://purl.org/dc/elements/1.1/format> "application/eml" <urn:uuid:adb92e81-2873-4549-9273-d4c12942cdb7> .
<https://gbif.laji.fi/eml/HR.2309.zip> <http://purl.org/dc/elements/1.1/format> "application/eml" <urn:uuid:8b280ef4-8929-41c1-beac-aa113a9f989b> .
<http://data.freshwaterbiodiversity.eu/ipt/eml.do?r=bfe_105> <http://purl.org/dc/elements/1.1/format> "application/eml" <urn:uuid:b825780a-6eb4-4100-b5fb-0cde2e47058f> .
<http://ipt.env.duke.edu/eml.do?r=zd_2043> <http://purl.org/dc/elements/1.1/format> "application/eml" <urn:uuid:1cca8b9a-7d0a-491f-a0b6-274ab08c4740> .
```

I didn't run exactly the example in the README, as I couldn't find the correct hash. I used this one instead:
`preston get hash://sha256/23d2e2c9f315bddb28d1dc4b4ed4a0c62ea6cfa347917ef5ad4db5be413798ab`