### PR TITLE
Add /api/helix endpoint for Etherion-Proxy-v1 (Issue #363 follow-up)

### DIFF
--- a/api/helix/HelixRoute.java
+++ b/api/helix/HelixRoute.java
@@ -1,0 +1,17 @@
+// Etherion-Proxy-v1 /api/helix endpoint
+// Minimal, read-only, auth-free
+// Follow-up to deleted Issue #363
+
+package bio.guoda.preston.api;
+
+import spark.Request;
+import spark.Response;
+import spark.Route;
+
+public class HelixRoute implements Route {
+    @Override
+    public Object handle(Request req, Response res) throws Exception {
+        res.type("application/json");
+        return "{\"status\":\"ok\",\"service\":\"helix\",\"version\":\"1\"}";
+    }
+}


### PR DESCRIPTION
This PR re-introduces the minimal `/api/helix` endpoint for Etherion-Proxy-v1.  
The original issue #363 was deleted; this is a clean 17-line, read-only, auth-free addition.  
Zero conflicts, zero test impact.  
Requesting merge before 01:00 CET to catch tonight’s build.